### PR TITLE
#115 map more fields to TaskInformation for C7Enbedded

### DIFF
--- a/engine-adapter/camunda-platform-7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/TaskInformationExtensions.kt
+++ b/engine-adapter/camunda-platform-7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/TaskInformationExtensions.kt
@@ -6,9 +6,10 @@ import org.camunda.bpm.engine.delegate.DelegateTask
 import org.camunda.bpm.engine.externaltask.LockedExternalTask
 import org.camunda.bpm.engine.impl.persistence.entity.ExternalTaskEntity
 import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity
+import org.camunda.bpm.engine.task.IdentityLink
 import org.camunda.bpm.engine.task.Task
 
-fun Task.toTaskInformation(processDefinitionKey: String? = null) =
+fun Task.toTaskInformation(candidates: List<IdentityLink>, processDefinitionKey: String? = null) =
   TaskInformation(
     taskId = this.id,
     meta = mapOf(
@@ -18,7 +19,13 @@ fun Task.toTaskInformation(processDefinitionKey: String? = null) =
       CommonRestrictions.PROCESS_INSTANCE_ID to this.processInstanceId,
       "taskName" to this.name,
       "taskDescription" to this.description,
-      "assignee" to this.assignee
+      "assignee" to this.assignee,
+      "creationDate" to this.createTime.toString(), // FIXME -> to zoned iso 8601
+      "followUpDate" to (this.followUpDate?.toString() ?: ""), // FIXME -> to zoned iso 8601
+      "dueDate" to (this.dueDate?.toString() ?: ""), // FIXME -> to zoned iso 8601
+      "formKey" to this.formKey,
+      "candidateUsers" to candidates.mapNotNull { it.userId }.joinToString(","),
+      "candidateGroups" to candidates.mapNotNull { it.groupId }.joinToString(",")
     ).let {
       if (processDefinitionKey != null) {
         it + (CommonRestrictions.PROCESS_DEFINITION_KEY to processDefinitionKey)
@@ -38,7 +45,13 @@ fun TaskEntity.toTaskInformation() =
       CommonRestrictions.PROCESS_INSTANCE_ID to this.processInstanceId,
       "taskName" to this.name,
       "taskDescription" to this.description,
-      "assignee" to this.assignee
+      "assignee" to this.assignee,
+      "creationDate" to this.createTime.toString(), // FIXME -> to zoned iso 8601
+      "followUpDate" to (this.followUpDate?.toString() ?: ""), // FIXME -> to zoned iso 8601
+      "dueDate" to (this.dueDate?.toString() ?: ""), // FIXME -> to zoned iso 8601
+      "formKey" to this.formKey,
+      "candidateUsers" to this.candidates.mapNotNull { it.userId }.joinToString(","),
+      "candidateGroups" to this.candidates.mapNotNull { it.groupId }.joinToString(",")
     )
   )
 
@@ -52,7 +65,12 @@ fun DelegateTask.toTaskInformation() =
       CommonRestrictions.PROCESS_INSTANCE_ID to this.processInstanceId,
       "taskName" to this.name,
       "taskDescription" to this.description,
-      "assignee" to this.assignee
+      "assignee" to this.assignee,
+      "creationDate" to this.createTime.toString(), // FIXME -> to zoned iso 8601
+      "followUpDate" to (this.followUpDate?.toString() ?: ""), // FIXME -> to zoned iso 8601
+      "dueDate" to (this.dueDate?.toString() ?: ""), // FIXME -> to zoned iso 8601,
+      "candidateUsers" to this.candidates.mapNotNull { it.userId }.joinToString(","),
+      "candidateGroups" to this.candidates.mapNotNull { it.groupId }.joinToString(",")
     )
   )
 

--- a/engine-adapter/camunda-platform-7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/pull/EmbeddedPullUserTaskDelivery.kt
+++ b/engine-adapter/camunda-platform-7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/pull/EmbeddedPullUserTaskDelivery.kt
@@ -38,6 +38,7 @@ class EmbeddedPullUserTaskDelivery(
       logger.trace { "PROCESS-ENGINE-C7-EMBEDDED-036: pulling user tasks for subscriptions: $subscriptions" }
       taskService
         .createTaskQuery()
+        .initializeFormKeys()
         .forSubscriptions(subscriptions)
         .list()
         .parallelStream()
@@ -51,7 +52,7 @@ class EmbeddedPullUserTaskDelivery(
                 try {
                   logger.debug { "PROCESS-ENGINE-C7-EMBEDDED-037: delivering user task ${task.id}." }
                   val processDefinitionKey = cachingProcessDefinitionKeyResolver.getProcessDefinitionKey(task.processDefinitionId)
-                  activeSubscription.action.accept(task.toTaskInformation(processDefinitionKey), variables)
+                  activeSubscription.action.accept(task.toTaskInformation(taskService.getIdentityLinksForTask(task.id), processDefinitionKey), variables)
                 } catch (e: Exception) {
                   logger.error { "PROCESS-ENGINE-C7-EMBEDDED-038: error delivering task ${task.id}: ${e.message}" }
                   subscriptionRepository.deactivateSubscriptionForTask(taskId = task.id)

--- a/engine-adapter/camunda-platform-7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/TaskInformationExtensionsKtTest.kt
+++ b/engine-adapter/camunda-platform-7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/TaskInformationExtensionsKtTest.kt
@@ -1,0 +1,101 @@
+package dev.bpmcrafters.processengineapi.adapter.c7.embedded.task.delivery
+
+import dev.bpmcrafters.processengineapi.CommonRestrictions
+import org.assertj.core.api.Assertions.assertThat
+import org.camunda.bpm.engine.impl.persistence.entity.IdentityLinkEntity
+import org.camunda.bpm.engine.task.IdentityLink
+import org.camunda.community.mockito.delegate.DelegateTaskFake
+import org.camunda.community.mockito.task.TaskFake
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.*
+
+class TaskInformationExtensionsKtTest {
+
+    @Test
+    fun `should map Task`() {
+        val now = Date.from(Instant.now())
+        val task = TaskFake.builder()
+            .id("taskId")
+            .processDefinitionId("processDefinitionId")
+            .processInstanceId("processInstanceId")
+            .tenantId("tenantId")
+            .taskDefinitionKey("taskDefinitionKey")
+            .name("name")
+            .description("description")
+            .assignee("assignee")
+            .createTime(now)
+            .followUpDate(now)
+            .dueDate(now)
+            .formKey("formKey")
+            .build()
+
+        val identityLinks =
+            listOf(identityLink(groupId = "group"), identityLink(userId = "user-1"), identityLink(userId = "user-2"))
+
+        val taskInformation = task.toTaskInformation(identityLinks, "processDefinitionKey")
+
+        assertThat(taskInformation.taskId).isEqualTo("taskId")
+        assertThat(taskInformation.meta[CommonRestrictions.PROCESS_DEFINITION_ID]).isEqualTo("processDefinitionId")
+        assertThat(taskInformation.meta[CommonRestrictions.PROCESS_DEFINITION_KEY]).isEqualTo("processDefinitionKey")
+        assertThat(taskInformation.meta[CommonRestrictions.TASK_DEFINITION_KEY]).isEqualTo("taskDefinitionKey")
+        assertThat(taskInformation.meta[CommonRestrictions.TENANT_ID]).isEqualTo("tenantId")
+        assertThat(taskInformation.meta["taskName"]).isEqualTo("name")
+        assertThat(taskInformation.meta["taskDescription"]).isEqualTo("description")
+        assertThat(taskInformation.meta["assignee"]).isEqualTo("assignee")
+        assertThat(taskInformation.meta["creationDate"]).isEqualTo(now.toString())
+        assertThat(taskInformation.meta["followUpDate"]).isEqualTo(now.toString())
+        assertThat(taskInformation.meta["dueDate"]).isEqualTo(now.toString())
+        assertThat(taskInformation.meta["formKey"]).isEqualTo("formKey")
+        assertThat(taskInformation.meta["candidateUsers"]).isEqualTo("user-1,user-2")
+        assertThat(taskInformation.meta["candidateGroups"]).isEqualTo("group")
+    }
+
+    @Test
+    fun `should map DelegateTask`() {
+        val now = Date.from(Instant.now())
+
+        var delegateTask = DelegateTaskFake("taskId")
+        delegateTask = delegateTask.withProcessDefinitionId("processDefinitionId")
+        delegateTask = delegateTask.withProcessInstanceId("processInstanceId")
+        delegateTask = delegateTask.withTenantId("tenantId")
+        delegateTask = delegateTask.withTaskDefinitionKey("taskDefinitionKey")
+        delegateTask = delegateTask.withName("name")
+        delegateTask = delegateTask.withDescription("description")
+        delegateTask = delegateTask.withAssignee("assignee")
+        delegateTask = delegateTask.withCreateTime(now)
+        delegateTask = delegateTask.withFollowUpDate(now)
+        delegateTask.dueDate = now
+        delegateTask.addGroupIdentityLink("group-1", "CANDIDATE")
+        delegateTask.addGroupIdentityLink("group-2", "CANDIDATE")
+        delegateTask.addUserIdentityLink("user-1", "CANDIDATE")
+        delegateTask.addUserIdentityLink("user-2", "CANDIDATE")
+
+        val taskInformation = delegateTask.toTaskInformation()
+
+        assertThat(taskInformation.taskId).isEqualTo("taskId")
+        assertThat(taskInformation.meta[CommonRestrictions.PROCESS_DEFINITION_ID]).isEqualTo("processDefinitionId")
+        assertThat(taskInformation.meta[CommonRestrictions.TASK_DEFINITION_KEY]).isEqualTo("taskDefinitionKey")
+        assertThat(taskInformation.meta[CommonRestrictions.TENANT_ID]).isEqualTo("tenantId")
+        assertThat(taskInformation.meta["taskName"]).isEqualTo("name")
+        assertThat(taskInformation.meta["taskDescription"]).isEqualTo("description")
+        assertThat(taskInformation.meta["assignee"]).isEqualTo("assignee")
+        assertThat(taskInformation.meta["creationDate"]).isEqualTo(now.toString())
+        assertThat(taskInformation.meta["followUpDate"]).isEqualTo(now.toString())
+        assertThat(taskInformation.meta["dueDate"]).isEqualTo(now.toString())
+        assertThat(taskInformation.meta["formKey"]).isNull()
+        assertThat(taskInformation.meta["candidateUsers"]).isEqualTo("user-1,user-2")
+        assertThat(taskInformation.meta["candidateGroups"]).isEqualTo("group-1,group-2")
+
+    }
+
+
+    private fun identityLink(userId: String? = null, groupId: String? = null): IdentityLink {
+        val identityLink = IdentityLinkEntity.newIdentityLink()
+        identityLink.userId = userId
+        identityLink.groupId = groupId
+        return identityLink
+    }
+
+
+}


### PR DESCRIPTION
Add `assignee`,  `creationDate`, `followUpDate`,  `dueDate`, `formKey`, `candidateUsers` and `candidateGroups` to `TaskInformation` for C7 Embedded

- closes  #115 