### PR TITLE
#116 set business key for camunda7 embedded and camunda7 remote

### DIFF
--- a/docs/reference-guide/process-api.md
+++ b/docs/reference-guide/process-api.md
@@ -47,3 +47,17 @@ public class ProcessStarter {
 
 
 ```
+
+For supported engines (currently only C7 Embedded and C7 Remote) it is possible to set a business key by providing it 
+in the payload supplier, for example:
+```java
+@SneakyThrows
+public void startByMessage(Order order) {
+    startProcessApi.startProcess(
+      new StartProcessByMessageCmd(
+        "Msg_OrderReceived",
+         () -> Map.of("order", order, CommonRestrictions.BUSINESS_KEY, "businessKey")
+     )
+    ).get();
+}
+```

--- a/engine-adapter/camunda-platform-7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/process/StartProcessApiImplTest.kt
+++ b/engine-adapter/camunda-platform-7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/process/StartProcessApiImplTest.kt
@@ -1,0 +1,108 @@
+package dev.bpmcrafters.processengineapi.adapter.c7.embedded.process
+
+import dev.bpmcrafters.processengineapi.CommonRestrictions
+import dev.bpmcrafters.processengineapi.process.StartProcessByDefinitionCmd
+import dev.bpmcrafters.processengineapi.process.StartProcessByMessageCmd
+import org.camunda.bpm.engine.RuntimeService
+import org.camunda.bpm.engine.runtime.MessageCorrelationBuilder
+import org.camunda.bpm.engine.runtime.ProcessInstance
+import org.camunda.community.mockito.process.ProcessInstanceFake
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class StartProcessApiImplTest {
+
+  @Mock
+  private lateinit var runtimeService: RuntimeService
+
+  @InjectMocks
+  private lateinit var startProcessApi: StartProcessApiImpl
+
+  @Test
+  fun `should start process via definition without payload`() {
+    // given
+    val startProcessByDefinitionCmd = StartProcessByDefinitionCmd("definitionKey") { emptyMap() }
+    val processInstance: ProcessInstance = ProcessInstanceFake.builder().id("someId").build()
+    `when`(runtimeService.startProcessInstanceByKey(anyString(), anyOrNull(), anyMap())).thenReturn(processInstance)
+
+    // when
+    startProcessApi.startProcess(startProcessByDefinitionCmd).get()
+
+    // then
+    verify(runtimeService).startProcessInstanceByKey("definitionKey", null, emptyMap())
+  }
+
+  @Test
+  fun `should start process via definition with payload and business key`() {
+    // given
+    val processInstance: ProcessInstance = ProcessInstanceFake.builder().id("someId").build()
+    `when`(runtimeService.startProcessInstanceByKey(anyString(), anyOrNull(), anyMap())).thenReturn(processInstance)
+    val startProcessByDefinitionCmd = StartProcessByDefinitionCmd("definitionKey") {
+      mapOf(
+        "key" to "value",
+        CommonRestrictions.BUSINESS_KEY to "businessKey"
+      )
+    }
+
+    // when
+    startProcessApi.startProcess(startProcessByDefinitionCmd).get()
+
+    // then
+    verify(runtimeService).startProcessInstanceByKey(
+      "definitionKey", "businessKey", mapOf(
+        "key" to "value",
+        CommonRestrictions.BUSINESS_KEY to "businessKey"
+      )
+    )
+  }
+
+  @Test
+  fun `should start process via message with business key`() {
+    // given
+    val payload = mapOf(CommonRestrictions.BUSINESS_KEY to "testBusinessKey", "key" to "value")
+    val startProcessByMessageCmd = StartProcessByMessageCmd("testMessage") { payload }
+    val correlationBuilder = messageCorrelationMock()
+    `when`(runtimeService.createMessageCorrelation(any())).thenReturn(correlationBuilder)
+
+    // When
+    startProcessApi.startProcess(startProcessByMessageCmd).get()
+
+    // Then
+    verify(runtimeService).createMessageCorrelation("testMessage")
+    verify(correlationBuilder).processInstanceBusinessKey("testBusinessKey")
+    verify(correlationBuilder).setVariables(mapOf(CommonRestrictions.BUSINESS_KEY to "testBusinessKey", "key" to "value"))
+  }
+
+  @Test
+  fun `should start process via message with payload`() {
+    // given
+    val payload = mapOf("key" to "value")
+    val startProcessByMessageCmd = StartProcessByMessageCmd("testMessage") { payload }
+    val correlationBuilder = messageCorrelationMock()
+    `when`(runtimeService.createMessageCorrelation(any())).thenReturn(correlationBuilder)
+
+    // When
+    startProcessApi.startProcess(startProcessByMessageCmd).get()
+
+    // Then
+    verify(runtimeService).createMessageCorrelation("testMessage")
+    verify(correlationBuilder).setVariables(mapOf("key" to "value"))
+    verify(correlationBuilder, times(0)).processInstanceBusinessKey(any())
+  }
+
+  private fun messageCorrelationMock(): MessageCorrelationBuilder {
+    val builder: MessageCorrelationBuilder = mock()
+    lenient().whenever(builder.processInstanceBusinessKey(any())).thenReturn(builder)
+    whenever(builder.setVariables(anyMap())).thenReturn(builder)
+    whenever(builder.correlateStartMessage()).thenReturn(ProcessInstanceFake.builder().id("someId").build())
+
+    return builder
+  }
+}

--- a/engine-adapter/camunda-platform-7-remote-core/pom.xml
+++ b/engine-adapter/camunda-platform-7-remote-core/pom.xml
@@ -12,13 +12,17 @@
   <artifactId>process-engine-api-adapter-camunda-platform-c7-remote-core</artifactId>
   <name>Adapter: C7 Remote Core</name>
 
+  <properties>
+    <camunda.version>7.22.0</camunda.version>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <!-- https://mvnrepository.com/artifact/org.camunda.bpm/camunda-bom -->
       <dependency>
         <groupId>org.camunda.bpm</groupId>
         <artifactId>camunda-bom</artifactId>
-        <version>7.22.0</version>
+        <version>${camunda.version}</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -48,6 +52,25 @@
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-engine</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <!-- Testing -->
+    <dependency>
+      <groupId>dev.bpm-crafters.process-engine-api</groupId>
+      <artifactId>process-engine-api-adapter-testing</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm</groupId>
+      <artifactId>camunda-bpm-junit5</artifactId>
+      <version>${camunda.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.community.mockito</groupId>
+      <artifactId>camunda-platform-7-mockito</artifactId>
+      <version>7.22.0</version>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/engine-adapter/camunda-platform-7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImplTest.kt
+++ b/engine-adapter/camunda-platform-7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImplTest.kt
@@ -30,13 +30,13 @@ class StartProcessApiImplTest {
   // given
   val startProcessByDefinitionCmd = StartProcessByDefinitionCmd("definitionKey") { emptyMap() }
   val processInstance: ProcessInstance = ProcessInstanceFake.builder().id("someId").build()
-  `when`(runtimeService.startProcessInstanceByKey(anyString(), anyOrNull(), anyMap())).thenReturn(processInstance)
+  `when`(runtimeService.startProcessInstanceByKey(anyString(), anyMap())).thenReturn(processInstance)
 
   // when
   startProcessApi.startProcess(startProcessByDefinitionCmd).get()
 
   // then
-  verify(runtimeService).startProcessInstanceByKey("definitionKey", null, emptyMap())
+  verify(runtimeService).startProcessInstanceByKey("definitionKey", emptyMap())
  }
 
  @Test

--- a/engine-adapter/camunda-platform-7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImplTest.kt
+++ b/engine-adapter/camunda-platform-7-remote-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/process/StartProcessApiImplTest.kt
@@ -1,0 +1,108 @@
+package dev.bpmcrafters.processengineapi.adapter.c7.remote.process
+
+import dev.bpmcrafters.processengineapi.CommonRestrictions
+import dev.bpmcrafters.processengineapi.process.StartProcessByDefinitionCmd
+import dev.bpmcrafters.processengineapi.process.StartProcessByMessageCmd
+import org.camunda.bpm.engine.RuntimeService
+import org.camunda.bpm.engine.runtime.MessageCorrelationBuilder
+import org.camunda.bpm.engine.runtime.ProcessInstance
+import org.camunda.community.mockito.process.ProcessInstanceFake
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class StartProcessApiImplTest {
+
+ @Mock
+ private lateinit var runtimeService: RuntimeService
+
+ @InjectMocks
+ private lateinit var startProcessApi: StartProcessApiImpl
+
+ @Test
+ fun `should start process via definition without payload`() {
+  // given
+  val startProcessByDefinitionCmd = StartProcessByDefinitionCmd("definitionKey") { emptyMap() }
+  val processInstance: ProcessInstance = ProcessInstanceFake.builder().id("someId").build()
+  `when`(runtimeService.startProcessInstanceByKey(anyString(), anyOrNull(), anyMap())).thenReturn(processInstance)
+
+  // when
+  startProcessApi.startProcess(startProcessByDefinitionCmd).get()
+
+  // then
+  verify(runtimeService).startProcessInstanceByKey("definitionKey", null, emptyMap())
+ }
+
+ @Test
+ fun `should start process via definition with payload and business key`() {
+  // given
+  val processInstance: ProcessInstance = ProcessInstanceFake.builder().id("someId").build()
+  `when`(runtimeService.startProcessInstanceByKey(anyString(), anyOrNull(), anyMap())).thenReturn(processInstance)
+  val startProcessByDefinitionCmd = StartProcessByDefinitionCmd("definitionKey") {
+   mapOf(
+    "key" to "value",
+    CommonRestrictions.BUSINESS_KEY to "businessKey"
+   )
+  }
+
+  // when
+  startProcessApi.startProcess(startProcessByDefinitionCmd).get()
+
+  // then
+  verify(runtimeService).startProcessInstanceByKey(
+   "definitionKey", "businessKey", mapOf(
+    "key" to "value",
+    CommonRestrictions.BUSINESS_KEY to "businessKey"
+   )
+  )
+ }
+
+ @Test
+ fun `should start process via message with business key`() {
+  // given
+  val payload = mapOf(CommonRestrictions.BUSINESS_KEY to "testBusinessKey", "key" to "value")
+  val startProcessByMessageCmd = StartProcessByMessageCmd("testMessage") { payload }
+  val correlationBuilder = messageCorrelationMock()
+  `when`(runtimeService.createMessageCorrelation(any())).thenReturn(correlationBuilder)
+
+  // When
+  startProcessApi.startProcess(startProcessByMessageCmd).get()
+
+  // Then
+  verify(runtimeService).createMessageCorrelation("testMessage")
+  verify(correlationBuilder).processInstanceBusinessKey("testBusinessKey")
+  verify(correlationBuilder).setVariables(mapOf(CommonRestrictions.BUSINESS_KEY to "testBusinessKey", "key" to "value"))
+ }
+
+ @Test
+ fun `should start process via message with payload`() {
+  // given
+  val payload = mapOf("key" to "value")
+  val startProcessByMessageCmd = StartProcessByMessageCmd("testMessage") { payload }
+  val correlationBuilder = messageCorrelationMock()
+  `when`(runtimeService.createMessageCorrelation(any())).thenReturn(correlationBuilder)
+
+  // When
+  startProcessApi.startProcess(startProcessByMessageCmd).get()
+
+  // Then
+  verify(runtimeService).createMessageCorrelation("testMessage")
+  verify(correlationBuilder).setVariables(mapOf("key" to "value"))
+  verify(correlationBuilder, times(0)).processInstanceBusinessKey(any())
+ }
+
+ private fun messageCorrelationMock(): MessageCorrelationBuilder {
+  val builder: MessageCorrelationBuilder = mock()
+  lenient().whenever(builder.processInstanceBusinessKey(any())).thenReturn(builder)
+  whenever(builder.setVariables(anyMap())).thenReturn(builder)
+  whenever(builder.correlateStartMessage()).thenReturn(ProcessInstanceFake.builder().id("someId").build())
+
+  return builder
+ }
+}


### PR DESCRIPTION
Business key can now be set for C7 (embedded & remote) by providing it in the payload
- closes #116 