### PR TITLE
Remove restriction `taskDefinitionKey`

### DIFF
--- a/api/src/main/kotlin/dev/bpmcrafters/processengineapi/CommonRestrictions.kt
+++ b/api/src/main/kotlin/dev/bpmcrafters/processengineapi/CommonRestrictions.kt
@@ -42,16 +42,6 @@ object CommonRestrictions {
   const val PROCESS_DEFINITION_VERSION_TAG = "processDefinitionVersionTag"
 
   /**
-   * Definition key of a task.
-   */
-  @Deprecated(
-    message = "Replaced by ACTIVITY_ID, since it a more generic term.",
-    replaceWith = ReplaceWith("ACTIVITY_ID"),
-    level = DeprecationLevel.WARNING
-  )
-  const val TASK_DEFINITION_KEY = "taskDefinitionKey"
-
-  /**
    * Tenant id.
    */
   const val TENANT_ID = "tenantId"
@@ -80,14 +70,6 @@ object CommonRestrictions {
 
     fun withProcessDefinitionKey(processDefinitionKey: String) = this.apply {
       restrictions[PROCESS_DEFINITION_KEY] = processDefinitionKey
-    }
-
-    @Deprecated(
-      message = "Replaced by withActivityId, since it a more generic term.",
-      replaceWith = ReplaceWith("withActivityId")
-    )
-    fun withTaskDefinitionKey(taskDefinitionKey: String) = this.apply {
-      restrictions[TASK_DEFINITION_KEY] = taskDefinitionKey
     }
 
     fun withTenantId(tenantId: String) = this.apply {

--- a/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/support/UserTaskSupport.kt
+++ b/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/support/UserTaskSupport.kt
@@ -66,10 +66,7 @@ class UserTaskSupport {
    * @return true if task exists.
    */
   fun exists(taskId: String, activityId: String?) =
-    information.containsKey(taskId) && (
-          information[taskId]?.meta?.get(CommonRestrictions.TASK_DEFINITION_KEY) == activityId
-            || information[taskId]?.meta?.get(CommonRestrictions.ACTIVITY_ID) == activityId
-        )
+    information.containsKey(taskId) && information[taskId]?.meta?.get(CommonRestrictions.ACTIVITY_ID) == activityId
 
   /**
    * Requires task to exist having the given id and task description key.

--- a/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/support/UserTaskSupport.kt
+++ b/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/support/UserTaskSupport.kt
@@ -65,7 +65,7 @@ class UserTaskSupport {
    * @param activityId activity id from XML.
    * @return true if task exists.
    */
-  fun exists(taskId: String, activityId: String?) =
+  fun exists(taskId: String, activityId: String?): Boolean =
     information.containsKey(taskId) && information[taskId]?.meta?.get(CommonRestrictions.ACTIVITY_ID) == activityId
 
   /**
@@ -75,8 +75,8 @@ class UserTaskSupport {
    * @throws IllegalArgumentException if no task can be found.
    */
   @Throws(IllegalArgumentException::class)
-  fun requireTask(taskId: String, activityId: String) {
-    require(exists(taskId, activityId)) { "Could not find task $taskId of type $activityId" }
+  fun requireTask(taskId: String, activityId: String?) {
+    require(exists(taskId, activityId)) { "Could not find task '$taskId' of type '$activityId'" }
   }
 
 

--- a/docs/developer-guide/project-setup.md
+++ b/docs/developer-guide/project-setup.md
@@ -35,6 +35,11 @@ command from your command line:
 python3 -m pip install --upgrade pip
 python3 -m pip install -r ./docs/requirements.txt
 ```
+Alternatively, you might want to install `pipx` on your machine and use that instead of Python 3 and virtual environments. Then run:
+
+```bash
+pipx -r ./docs/requirements.txt
+```
 
 For creation of documentation, please run:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ Sounds interesting for you? Try it out, and provide us some feedback...
 ## How to start?
 
 We provide documentation for different people and different tasks. A good starting point is the
-[Introduction](./introduction). You might want to look at [Reference Guide](./reference-guide).
+[Introduction](./introduction/index.md). You might want to look at [Reference Guide](./reference-guide/index.md).
 
 ## Get in touch
 

--- a/docs/reference-guide/index.md
+++ b/docs/reference-guide/index.md
@@ -1,3 +1,9 @@
+---
+title: Overview
+---
+
+## Process Engine API
+
 The `process-engine-api` provides an API to abstract from a concrete process engine implementation, with the ability
 to write your application code engine-agnostic and later (re-)configure for the usage of a particular process engine.
 
@@ -40,3 +46,13 @@ we provide a special API to complete tasks.
 
 The [User Task Completion API](user-task-completion-api.md) provides functionality to deal with user tasks. Since the Task Subscription API allows asynchronous processing,
 we provide a special API to complete tasks. 
+
+## Other Helpful Components
+
+### User Task Support
+
+The [User Task Support](user-task-support.md) is a small component simplifying use cases related to user tasks. It can be hooked up into Task Subscription API
+and receive and store the received user tasks. If later you want to access a task delivered in the past, its `TaskInformation` and payload are available in the
+User Task Support component.
+
+

--- a/docs/reference-guide/user-task-support.md
+++ b/docs/reference-guide/user-task-support.md
@@ -1,0 +1,66 @@
+---
+title: User Task Support
+---
+
+## Configuration
+
+The [User Task Support](user-task-support.md) is a small component simplifying use cases related to user tasks. It can be hooked up into Task Subscription API
+and receive and store the received user tasks. If later you want to access a task delivered in the past, its `TaskInformation` and payload are available in the
+User Task Support component.
+
+User Task Support is a passive component and needs to be instantiated and registered to the subscription API. This behaviour is implemented in order to allow 
+the user of it, to customize the subscription restrictions (e.g. subscribing only for a certain process definition key, or certain tenant). 
+
+To configure and register `User Task Support` use the following code:
+
+```java
+
+import dev.bpmcrafters.processengineapi.task.support.UserTaskSupport;
+
+@Configuration
+@RequiredArgsConstructor
+public class UserTaskSupportConfiguration {
+  
+  @Bean
+  public UserTaskSupport createAndRegisterUserTaskSupport(TaskSubscriptionApi taskSubscriptionApi) {
+    UserTaskSupport support = new UserTaskSupport();
+    support.subscribe(
+      taskSubscriptionApi, 
+      CommonRestrictions.builder().build(), 
+      null, // String parameter to limit the taskDescriptionKey, see SubscribeForTaskCmd 
+      null // no restriction of the payload, see SubscribeForTaskCmd
+    );
+    return support;
+  }
+  
+}
+```
+
+User Task Support provides API for the following User-Task-related use cases. For retrieving information and payload about the task by given 
+task id (task existence is enforced) or information of all tasks:
+
+  - `getTaskInformation(taskId: String): TaskInformation` 
+  - `getPayload(taskId: String): Map<String, Any>`
+  - `getAllTasks(): List<TaskInformation>`
+
+Checking or enforce task existence:
+  
+  - `exists(taskId: String, activityId: String?): Boolean`
+  - `requireTask(taskId: String, activityId: String?)`
+
+In addition to the API for task retrieval offered by the `User Task Support` component, it allows to register additional `TaskHandler` and `TaskTerminationHandler`
+directly and acts as a composite handler, invoking both on corresponding task lifecycle events. This is in particular helpful, if you implement any kind
+of forwarding or notification logic for the user tasks:
+
+  - `addTaskHandler(handler: TaskHandler)`
+  - `addTaskTerminationHandler(handler: TaskTerminationHandler)`
+
+## Typical usage
+
+Typically, implementation of task-related use cases require access via inbound adapters to your use case based on some reference to the user task. Often, systems for 
+delivery of user tasks or user tasks notification will use the task id as the only reference to the task. The use case implementation needs to resolve the reference, 
+load some information, which is shown to user on a user task form and finally receive a task command executing one of the common task operations (complete, etc...)
+
+For the implementation of those, you would need to outbound adapters: `UserTaskSupport` for resolving task reference and `UserTaskCompletionAPI` for sending out commands.
+See our provided examples for more details.
+

--- a/engine-adapter/camunda-platform-7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/TaskInformationExtensions.kt
+++ b/engine-adapter/camunda-platform-7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/TaskInformationExtensions.kt
@@ -14,7 +14,6 @@ fun Task.toTaskInformation(candidates: List<IdentityLink>, processDefinitionKey:
     taskId = this.id,
     meta = mapOf(
       CommonRestrictions.PROCESS_DEFINITION_ID to this.processDefinitionId,
-      CommonRestrictions.TASK_DEFINITION_KEY to this.taskDefinitionKey,
       CommonRestrictions.ACTIVITY_ID to this.taskDefinitionKey,
       CommonRestrictions.TENANT_ID to this.tenantId,
       CommonRestrictions.PROCESS_INSTANCE_ID to this.processInstanceId,
@@ -41,7 +40,7 @@ fun TaskEntity.toTaskInformation() =
     taskId = this.id,
     meta = mapOf(
       CommonRestrictions.PROCESS_DEFINITION_ID to this.processDefinitionId,
-      CommonRestrictions.TASK_DEFINITION_KEY to this.taskDefinitionKey,
+      CommonRestrictions.ACTIVITY_ID to this.taskDefinitionKey,
       CommonRestrictions.TENANT_ID to this.tenantId,
       CommonRestrictions.PROCESS_INSTANCE_ID to this.processInstanceId,
       "taskName" to this.name,
@@ -61,7 +60,7 @@ fun DelegateTask.toTaskInformation() =
     taskId = this.id,
     meta = mapOf(
       CommonRestrictions.PROCESS_DEFINITION_ID to this.processDefinitionId,
-      CommonRestrictions.TASK_DEFINITION_KEY to this.taskDefinitionKey,
+      CommonRestrictions.ACTIVITY_ID to this.taskDefinitionKey,
       CommonRestrictions.TENANT_ID to this.tenantId,
       CommonRestrictions.PROCESS_INSTANCE_ID to this.processInstanceId,
       "taskName" to this.name,
@@ -77,26 +76,28 @@ fun DelegateTask.toTaskInformation() =
 
 fun LockedExternalTask.toTaskInformation(): TaskInformation {
   return TaskInformation(
-    this.id,
-    mapOf(
+    taskId = this.id,
+    meta = mapOf(
       CommonRestrictions.PROCESS_DEFINITION_ID to this.processDefinitionId,
       CommonRestrictions.PROCESS_DEFINITION_KEY to this.processDefinitionKey,
       CommonRestrictions.PROCESS_INSTANCE_ID to this.processInstanceId,
       CommonRestrictions.TENANT_ID to this.tenantId,
-      CommonRestrictions.ACTIVITY_ID to this.activityId
+      CommonRestrictions.ACTIVITY_ID to this.activityId,
+      "topicName" to this.topicName,
     )
   )
 }
 
 fun ExternalTaskEntity.toTaskInformation(): TaskInformation {
   return TaskInformation(
-    this.id,
-    mapOf(
+    taskId = this.id,
+    meta = mapOf(
       CommonRestrictions.PROCESS_DEFINITION_ID to this.processDefinitionId,
       CommonRestrictions.PROCESS_DEFINITION_KEY to this.processDefinitionKey,
       CommonRestrictions.PROCESS_INSTANCE_ID to this.processInstanceId,
       CommonRestrictions.TENANT_ID to this.tenantId,
-      CommonRestrictions.ACTIVITY_ID to this.activityId
+      CommonRestrictions.ACTIVITY_ID to this.activityId,
+      "topicName" to this.topicName,
     )
   )
 }

--- a/engine-adapter/camunda-platform-7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/event/EmbeddedEventBasedUserTaskDelivery.kt
+++ b/engine-adapter/camunda-platform-7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/event/EmbeddedEventBasedUserTaskDelivery.kt
@@ -17,7 +17,7 @@ class EmbeddedEventBasedUserTaskDelivery(
 ) : UserTaskDelivery {
 
   fun userTaskCreated(delegateTask: DelegateTask) {
-    val subscriptions = subscriptionRepository.getTaskSubscriptions()
+    val subscriptions = subscriptionRepository.getTaskSubscriptions().filter { s -> s.taskType == TaskType.USER }
 
     subscriptions
       .firstOrNull { subscription -> subscription.matches(delegateTask) }

--- a/engine-adapter/camunda-platform-7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/pull/EmbeddedPullServiceTaskDelivery.kt
+++ b/engine-adapter/camunda-platform-7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/pull/EmbeddedPullServiceTaskDelivery.kt
@@ -35,7 +35,7 @@ class EmbeddedPullServiceTaskDelivery(
    */
   override fun refresh() {
 
-    val subscriptions = subscriptionRepository.getTaskSubscriptions()
+    val subscriptions = subscriptionRepository.getTaskSubscriptions().filter { s -> s.taskType == TaskType.EXTERNAL }
     if (subscriptions.isNotEmpty()) {
       logger.trace { "PROCESS-ENGINE-C7-EMBEDDED-030: pulling service tasks for subscriptions: $subscriptions" }
       // TODO -> how many queries do we want? 1:1 subscriptions, or 1 query for all?
@@ -89,7 +89,7 @@ class EmbeddedPullServiceTaskDelivery(
       && this.restrictions.all {
       when (it.key) {
         CommonRestrictions.EXECUTION_ID -> it.value == task.executionId
-        CommonRestrictions.ACTIVITY_ID -> it.value == task.activityInstanceId // FIXME task.activityId?
+        CommonRestrictions.ACTIVITY_ID -> it.value == task.activityId
         CommonRestrictions.BUSINESS_KEY -> it.value == task.businessKey
         CommonRestrictions.TENANT_ID -> it.value == task.tenantId
         CommonRestrictions.PROCESS_INSTANCE_ID -> it.value == task.processInstanceId

--- a/engine-adapter/camunda-platform-7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/testing/AbstractC7EmbeddedStage.kt
+++ b/engine-adapter/camunda-platform-7-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/testing/AbstractC7EmbeddedStage.kt
@@ -344,12 +344,12 @@ abstract class AbstractC7EmbeddedStage<SUBTYPE : AbstractC7EmbeddedStage<SUBTYPE
     return BpmnAwareTests.processInstanceQuery().processInstanceId(processInstanceId).singleResult()
   }
 
-  private fun findTaskByActivityId(taskDescriptionKey: String): Optional<String> {
+  private fun findTaskByActivityId(activityId: String): Optional<String> {
     embeddedPullUserTaskDelivery.refresh()
     return Optional.ofNullable(
       userTaskSupport
         .getAllTasks()
-        .find { ti: TaskInformation -> ti.meta[CommonRestrictions.TASK_DEFINITION_KEY] == taskDescriptionKey }?.taskId
+        .find { ti: TaskInformation -> ti.meta[CommonRestrictions.ACTIVITY_ID] == activityId }?.taskId
     )
   }
 }

--- a/engine-adapter/camunda-platform-7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/TaskInformationExtensionsKtTest.kt
+++ b/engine-adapter/camunda-platform-7-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/embedded/task/delivery/TaskInformationExtensionsKtTest.kt
@@ -38,7 +38,6 @@ class TaskInformationExtensionsKtTest {
         assertThat(taskInformation.taskId).isEqualTo("taskId")
         assertThat(taskInformation.meta[CommonRestrictions.PROCESS_DEFINITION_ID]).isEqualTo("processDefinitionId")
         assertThat(taskInformation.meta[CommonRestrictions.PROCESS_DEFINITION_KEY]).isEqualTo("processDefinitionKey")
-        assertThat(taskInformation.meta[CommonRestrictions.TASK_DEFINITION_KEY]).isEqualTo("taskDefinitionKey")
         assertThat(taskInformation.meta[CommonRestrictions.TENANT_ID]).isEqualTo("tenantId")
         assertThat(taskInformation.meta["taskName"]).isEqualTo("name")
         assertThat(taskInformation.meta["taskDescription"]).isEqualTo("description")
@@ -75,7 +74,7 @@ class TaskInformationExtensionsKtTest {
 
         assertThat(taskInformation.taskId).isEqualTo("taskId")
         assertThat(taskInformation.meta[CommonRestrictions.PROCESS_DEFINITION_ID]).isEqualTo("processDefinitionId")
-        assertThat(taskInformation.meta[CommonRestrictions.TASK_DEFINITION_KEY]).isEqualTo("taskDefinitionKey")
+        assertThat(taskInformation.meta[CommonRestrictions.ACTIVITY_ID]).isEqualTo("taskDefinitionKey")
         assertThat(taskInformation.meta[CommonRestrictions.TENANT_ID]).isEqualTo("tenantId")
         assertThat(taskInformation.meta["taskName"]).isEqualTo("name")
         assertThat(taskInformation.meta["taskDescription"]).isEqualTo("description")

--- a/engine-adapter/camunda-platform-7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/TaskInformationExtensions.kt
+++ b/engine-adapter/camunda-platform-7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/TaskInformationExtensions.kt
@@ -11,12 +11,12 @@ fun RemoteExternalTask.toTaskInformation(): TaskInformation = TaskInformation(
   taskId = this.id,
   meta = mapOf(
     CommonRestrictions.TENANT_ID to this.tenantId,
-    CommonRestrictions.TASK_DEFINITION_KEY to this.topicName,
     CommonRestrictions.ACTIVITY_ID to this.activityId,
     CommonRestrictions.PROCESS_DEFINITION_KEY to this.processDefinitionKey,
     CommonRestrictions.PROCESS_INSTANCE_ID to this.processInstanceId,
     CommonRestrictions.PROCESS_DEFINITION_ID to this.processDefinitionId,
     CommonRestrictions.PROCESS_DEFINITION_VERSION_TAG to this.processDefinitionVersionTag,
+    "topicName" to this.topicName,
     // FIXME more
   )
 )
@@ -25,13 +25,12 @@ fun LockedExternalTask.toTaskInformation(): TaskInformation = TaskInformation(
   taskId = this.id,
   meta = mapOf(
     CommonRestrictions.TENANT_ID to this.tenantId,
-    CommonRestrictions.TASK_DEFINITION_KEY to this.topicName,
     CommonRestrictions.ACTIVITY_ID to this.activityId,
     CommonRestrictions.PROCESS_DEFINITION_KEY to this.processDefinitionKey,
     CommonRestrictions.PROCESS_INSTANCE_ID to this.processInstanceId,
     CommonRestrictions.PROCESS_DEFINITION_ID to this.processDefinitionId,
     CommonRestrictions.PROCESS_DEFINITION_VERSION_TAG to this.processDefinitionVersionTag,
-    // FIXME more
+    "topicName" to this.topicName,
   )
 )
 
@@ -39,7 +38,6 @@ fun Task.toTaskInformation() =
   TaskInformation(
     taskId = this.id,
     meta = mapOf(
-      CommonRestrictions.TASK_DEFINITION_KEY to this.taskDefinitionKey,
       CommonRestrictions.ACTIVITY_ID to this.taskDefinitionKey,
       CommonRestrictions.TENANT_ID to this.tenantId,
       CommonRestrictions.PROCESS_INSTANCE_ID to this.processInstanceId,

--- a/engine-adapter/camunda-platform-7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/subscribe/SubscribingClientServiceTaskDelivery.kt
+++ b/engine-adapter/camunda-platform-7-remote-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c7/remote/task/delivery/subscribe/SubscribingClientServiceTaskDelivery.kt
@@ -123,6 +123,6 @@ class SubscribingClientServiceTaskDelivery(
     } else {
       this
     }
-    // FIXME -> consider complex tent filtering
+    // FIXME -> consider complex tenant filtering
   }
 }

--- a/engine-adapter/camunda-platform-8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/PullUserTaskDelivery.kt
+++ b/engine-adapter/camunda-platform-8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/PullUserTaskDelivery.kt
@@ -20,7 +20,7 @@ class PullUserTaskDelivery(
 ) : RefreshableDelivery {
 
   override fun refresh() {
-    val subscriptions = subscriptionRepository.getTaskSubscriptions()
+    val subscriptions = subscriptionRepository.getTaskSubscriptions().filter { s -> s.taskType == TaskType.USER }
 
     // FIXME -> reverse lookup for all active subscriptions
     // if the task is not retrieved but active subscription has a task, call modification#terminated hook
@@ -60,9 +60,6 @@ class PullUserTaskDelivery(
 
   private fun TaskSearch.forSubscriptions(subscriptions: List<TaskSubscriptionHandle>): TaskSearch {
     // FIXME -> support tenant on subscription
-    subscriptions
-      .filter { it.taskType == TaskType.USER } // only user task subscriptions
-      .map { it.taskDescriptionKey to it.restrictions }
     // FIXME -> consider complex tent filtering
     return this
   }
@@ -75,6 +72,7 @@ class PullUserTaskDelivery(
         CommonRestrictions.TENANT_ID -> it.value == task.tenantId
         CommonRestrictions.PROCESS_INSTANCE_ID -> it.value == task.processInstanceKey
         CommonRestrictions.PROCESS_DEFINITION_ID -> it.value == task.processDefinitionKey
+        // FIXME -> more restrictions
         else -> false
       }
     }

--- a/engine-adapter/camunda-platform-8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingRefreshingUserTaskDelivery.kt
+++ b/engine-adapter/camunda-platform-8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingRefreshingUserTaskDelivery.kt
@@ -30,7 +30,7 @@ class SubscribingRefreshingUserTaskDelivery(
   private var jobWorkerRegistry: Map<String, JobWorker> = emptyMap()
 
   fun subscribe() {
-    val subscriptions = subscriptionRepository.getTaskSubscriptions()
+    val subscriptions = subscriptionRepository.getTaskSubscriptions().filter { s -> s.taskType == TaskType.USER }
     if (subscriptions.isNotEmpty()) {
       logger.trace { "PROCESS-ENGINE-C8-040: subscribing user tasks for subscriptions: $subscriptions" }
       subscriptions

--- a/engine-adapter/camunda-platform-8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingServiceTaskDelivery.kt
+++ b/engine-adapter/camunda-platform-8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingServiceTaskDelivery.kt
@@ -22,7 +22,7 @@ class SubscribingServiceTaskDelivery(
 ) {
 
   fun subscribe() {
-    val subscriptions = subscriptionRepository.getTaskSubscriptions()
+    val subscriptions = subscriptionRepository.getTaskSubscriptions().filter { s -> s.taskType == TaskType.EXTERNAL }
     if (subscriptions.isNotEmpty()) {
       logger.trace { "PROCESS-ENGINE-C8-050: subscribing service tasks for subscriptions: $subscriptions" }
       subscriptions

--- a/engine-adapter/camunda-platform-8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/TaskInformationExtensions.kt
+++ b/engine-adapter/camunda-platform-8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/TaskInformationExtensions.kt
@@ -10,7 +10,6 @@ fun ActivatedJob.toTaskInformation(): TaskInformation = TaskInformation(
   taskId = "${this.key}",
   meta = mapOf(
     CommonRestrictions.TENANT_ID to this.tenantId,
-    CommonRestrictions.TASK_DEFINITION_KEY to this.elementId,
     CommonRestrictions.ACTIVITY_ID to this.elementId,
     CommonRestrictions.PROCESS_DEFINITION_KEY to this.bpmnProcessId,
     CommonRestrictions.PROCESS_DEFINITION_ID to "${this.processDefinitionKey}",
@@ -21,13 +20,13 @@ fun ActivatedJob.toTaskInformation(): TaskInformation = TaskInformation(
     "candidateUsers" to this.customHeaders.getOrDefault(Protocol.USER_TASK_CANDIDATE_USERS_HEADER_NAME, null),
     "candidateGroups" to this.customHeaders.getOrDefault(Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME, null),
     "followUpDate" to this.customHeaders.getOrDefault(Protocol.USER_TASK_FOLLOW_UP_DATE_HEADER_NAME, null),
+    "topicName" to this.type,
   )
 )
 
 fun Task.toTaskInformation(): TaskInformation = TaskInformation(
   taskId = this.id,
   meta = mapOf(
-    CommonRestrictions.TASK_DEFINITION_KEY to this.taskDefinitionId,
     CommonRestrictions.ACTIVITY_ID to this.taskDefinitionId,
     CommonRestrictions.PROCESS_DEFINITION_KEY to this.processDefinitionKey,
     CommonRestrictions.PROCESS_INSTANCE_ID to this.processInstanceKey,

--- a/engine-adapter/camunda-platform-8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/testing/AbstractC8ProcessStage.kt
+++ b/engine-adapter/camunda-platform-8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/testing/AbstractC8ProcessStage.kt
@@ -320,10 +320,10 @@ abstract class AbstractC8ProcessStage<SUBTYPE : AbstractC8ProcessStage<SUBTYPE>>
         .filter { record -> record.intent == ProcessInstanceIntent.ELEMENT_COMPLETED }
     }
 
-  private fun findTaskByActivityId(taskDescriptionKey: String): Optional<String> {
+  private fun findTaskByActivityId(activityId: String): Optional<String> {
     return Optional.ofNullable(
       userTaskSupport.getAllTasks()
-        .find { taskInformation -> taskInformation.meta[CommonRestrictions.TASK_DEFINITION_KEY] == taskDescriptionKey }?.taskId
+        .find { taskInformation -> taskInformation.meta[CommonRestrictions.ACTIVITY_ID] == activityId }?.taskId
     )
   }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
     - Task Subscription API: reference-guide/task-subscription-api.md
     - Service Task Completion API: reference-guide/service-task-completion-api.md
     - User Task Completion API: reference-guide/user-task-completion-api.md
+    - User Task Support: reference-guide/user-task-support.md
   - Developers:
     - Contribution: developer-guide/contribution.md
     - Project Setup: developer-guide/project-setup.md


### PR DESCRIPTION
- remove unneeded restriction `taskDefinitionKey`
- improve task subscriptions in delivery
- fix bpm-crafters/process-engine-api#210