### PR TITLE
Task handlers with reasons and value based commands

### DIFF
--- a/api/src/main/kotlin/dev/bpmcrafters/processengineapi/correlation/CorrelateMessageCmd.kt
+++ b/api/src/main/kotlin/dev/bpmcrafters/processengineapi/correlation/CorrelateMessageCmd.kt
@@ -10,4 +10,20 @@ data class CorrelateMessageCmd(
   val messageName: String,
   val payloadSupplier: PayloadSupplier,
   val correlation: CorrelationSupplier
-) : PayloadSupplier by payloadSupplier
+) : PayloadSupplier by payloadSupplier {
+  /**
+   * Constructs a correlation command by message name, payload and correlation.
+   * @param messageName message name.
+   * @param payload payload to use.
+   * @param correlation correlation to use.
+   */
+  constructor(messageName: String, payload: Map<String, Any>, correlation: Correlation) :
+    this(messageName = messageName, payloadSupplier = PayloadSupplier { payload }, correlation = CorrelationSupplier { correlation} )
+  /**
+   * Constructs a correlation command by message name, no payload and correlation.
+   * @param messageName message name.
+   * @param correlation correlation to use.
+   */
+  constructor(messageName: String, correlation: Correlation) : this(messageName, mapOf() , correlation)
+
+}

--- a/api/src/main/kotlin/dev/bpmcrafters/processengineapi/correlation/CorrelationSupplier.kt
+++ b/api/src/main/kotlin/dev/bpmcrafters/processengineapi/correlation/CorrelationSupplier.kt
@@ -6,4 +6,4 @@ import java.util.function.Supplier
  * Correlation supplier.
  * @since 0.0.1
  */
-interface CorrelationSupplier : Supplier<Correlation>
+fun interface CorrelationSupplier : Supplier<Correlation>

--- a/api/src/main/kotlin/dev/bpmcrafters/processengineapi/correlation/SendSignalCmd.kt
+++ b/api/src/main/kotlin/dev/bpmcrafters/processengineapi/correlation/SendSignalCmd.kt
@@ -10,4 +10,19 @@ data class SendSignalCmd(
   val signalName: String,
   val payloadSupplier: PayloadSupplier,
   val restrictions: Map<String, String>
-) : PayloadSupplier by payloadSupplier
+) : PayloadSupplier by payloadSupplier {
+  /**
+   * Constructs a signal command by signal name, restrictions and given payload.
+   * @param signalName signal name.
+   * @param restrictions restrictions.
+   * @param payload payload to use.
+   */
+  constructor(signalName: String, restrictions: Map<String, String>, payload: Map<String, Any>) : this(signalName, PayloadSupplier { payload }, restrictions )
+  /**
+   * Constructs a signal command by signal name, restrictions and no payload.
+   * @param signalName signal name.
+   * @param restrictions restrictions.
+   */
+  constructor(signalName: String, restrictions: Map<String, String>) : this(signalName, restrictions, mapOf() )
+
+}

--- a/api/src/main/kotlin/dev/bpmcrafters/processengineapi/process/StartProcessByDefinitionCmd.kt
+++ b/api/src/main/kotlin/dev/bpmcrafters/processengineapi/process/StartProcessByDefinitionCmd.kt
@@ -15,4 +15,16 @@ data class StartProcessByDefinitionCmd(
    * Payload supplier to pass to the new process instance.
    */
   val payloadSupplier: PayloadSupplier
-) : StartProcessCommand, PayloadSupplier by payloadSupplier
+) : StartProcessCommand, PayloadSupplier by payloadSupplier {
+  /**
+   * Constructs a start command with definition key and payload.
+   * @param definitionKey process definition key.
+   * @param payload payload to use.
+   */
+  constructor(definitionKey: String, payload: Map<String, Any>) : this(definitionKey, PayloadSupplier { payload } )
+  /**
+   * Constructs a start command with definition key and no payload.
+   * @param definitionKey process definition key.
+   */
+  constructor(definitionKey: String) : this(definitionKey, mapOf() )
+}

--- a/api/src/main/kotlin/dev/bpmcrafters/processengineapi/process/StartProcessByMessageCmd.kt
+++ b/api/src/main/kotlin/dev/bpmcrafters/processengineapi/process/StartProcessByMessageCmd.kt
@@ -15,4 +15,17 @@ data class StartProcessByMessageCmd(
    * Payload supplier.
    */
   val payloadSupplier: PayloadSupplier
-) : StartProcessCommand, PayloadSupplier by payloadSupplier
+) : StartProcessCommand, PayloadSupplier by payloadSupplier {
+  /**
+   * Constructs a start command by message name and payload.
+   * @param messageName message name.
+   * @param payload payload to use.
+   */
+  constructor(messageName: String, payload: Map<String, Any>) : this(messageName, PayloadSupplier { payload } )
+  /**
+   * Constructs a start command by message and no payload.
+   * @param messageName message name.
+   */
+  constructor(messageName: String) : this(messageName, mapOf() )
+
+}

--- a/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/CompleteTaskByErrorCmd.kt
+++ b/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/CompleteTaskByErrorCmd.kt
@@ -23,4 +23,27 @@ open class CompleteTaskByErrorCmd(
    * Payload supplier.
    */
   private val payloadSupplier: PayloadSupplier
-) : PayloadSupplier by payloadSupplier
+) : PayloadSupplier by payloadSupplier {
+  /**
+   * Creates the complete command for a given task id and payload.
+   * @param taskId id of the task to complete.
+   * @param errorCode error.
+   * @param errorMessage Optional details.
+   * @param payload payload to use.
+   */
+  constructor(taskId: String, errorCode: String, errorMessage: String?, payload: Map<String, Any>) : this(
+    taskId = taskId,
+    errorCode = errorCode,
+    errorMessage = errorMessage,
+    payloadSupplier = PayloadSupplier { payload }
+  )
+
+  /**
+   * Creates the complete command for a given task id without payload.
+   * @param taskId id of the task to complete.
+   * @param errorCode error.
+   * @param errorMessage Optional details.
+   */
+  constructor(taskId: String, errorCode: String, errorMessage: String?) : this(taskId, errorCode, errorMessage, mapOf() )
+
+}

--- a/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/CompleteTaskCmd.kt
+++ b/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/CompleteTaskCmd.kt
@@ -15,4 +15,18 @@ open class CompleteTaskCmd(
    * Payload supplier.
    */
   private val payloadSupplier: PayloadSupplier
-) : PayloadSupplier by payloadSupplier
+) : PayloadSupplier by payloadSupplier {
+
+  /**
+   * Creates the complete command for a given task id and payload.
+   * @param taskId id of the task to complete.
+   * @param payload payload to use.
+   */
+  constructor(taskId: String, payload: Map<String, Any>) : this(taskId, PayloadSupplier { payload } )
+
+  /**
+   * Creates the complete command for a given task id without payload.
+   * @param taskId id of the task to complete.
+   */
+  constructor(taskId: String) : this(taskId, mapOf() )
+}

--- a/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/SubscribeForTaskCmd.kt
+++ b/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/SubscribeForTaskCmd.kt
@@ -1,5 +1,7 @@
 package dev.bpmcrafters.processengineapi.task
 
+import java.util.function.Consumer
+
 /**
  * Command to subscribe to tasks.
  * @since 0.0.1
@@ -34,4 +36,38 @@ data class SubscribeForTaskCmd(
    * Action to execute if the delivered task is terminated.
    */
   val termination: TaskTerminationHandler
-)
+) {
+  constructor(
+    /**
+     * Defines a set of restrictions evaluated by the engine adapter.
+     */
+    restrictions: Map<String, String>,
+    /**
+     * Task type.
+     */
+    taskType: TaskType,
+    /**
+     * May refer to BPMN 2.0 attribute `implementation` or `operation[@implementationRef]` or
+     * any engine-specific attribute of the task XML-tag. As a fallback an adapter-implementation
+     * should also accept a task's `id` attribute, since this the only common attribute in all engines.
+     */
+    taskDescriptionKey: String?,
+    /**
+     * Limitation of the payload variables to be delivered to the action.
+     * If empty, no variables should be provided.
+     * If non-empty, the variables are limited to those, provided in the list.
+     * If null, all variables are provided.
+     */
+    payloadDescription: Set<String>? = null,
+    /**
+     * Action to deliver the task to.
+     */
+    action: TaskHandler,
+    /**
+     * Action to execute if the delivered task is terminated.
+     */
+    termination: Consumer<String>
+  ) : this(restrictions, taskType, taskDescriptionKey, payloadDescription, action, TaskTerminationHandler { taskInformation ->
+    termination.accept(taskInformation.taskId)
+  })
+}

--- a/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/TaskHandler.kt
+++ b/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/TaskHandler.kt
@@ -6,4 +6,11 @@ import java.util.function.BiConsumer
  * Task handler receiving task information and payload.
  * @since 0.0.1
  */
-fun interface TaskHandler : BiConsumer<TaskInformation, Map<String, Any>>
+@JvmDefaultWithoutCompatibility
+fun interface TaskHandler : BiConsumer<TaskInformation, Map<String, Any>> {
+
+  fun process(parameters: Pair<TaskInformation, Map<String, Any>>): Pair<TaskInformation, Map<String, Any>> {
+    accept(parameters.first, parameters.second)
+    return parameters
+  }
+}

--- a/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/TaskInformation.kt
+++ b/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/TaskInformation.kt
@@ -13,4 +13,31 @@ data class TaskInformation(
    * Additional metadata about the task.
    */
   val meta: Map<String, String>
-)
+) {
+  companion object {
+    const val REASON = "reason"
+
+    const val CREATE = "create"
+    const val ASSIGN = "assign"
+    const val UPDATE = "update"
+    const val COMPLETE = "complete"
+    const val DELETE = "delete"
+  }
+
+  /**
+   * Creates a new task information with specified reason.
+   * @param reason reason to set.
+   * @return task information.
+   */
+  fun withReason(reason: String): TaskInformation {
+    return this.copy(meta = meta + (REASON to reason))
+  }
+
+  /**
+   * Cleans up th reason, if previously available.
+   * @return task information without reason set.
+   */
+  fun cleanupReason(): TaskInformation {
+    return this.copy(meta = meta.filterNot { it.key == REASON })
+  }
+}

--- a/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/TaskTerminationHandler.kt
+++ b/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/TaskTerminationHandler.kt
@@ -6,4 +6,11 @@ import java.util.function.Consumer
  * Handler that is invoked if the task is deleted after the task has been assigned to the task handler.
  * @since 0.0.1
  */
-fun interface TaskTerminationHandler : Consumer<String>
+@JvmDefaultWithoutCompatibility
+fun interface TaskTerminationHandler : Consumer<TaskInformation> {
+
+  fun process(taskInformation: TaskInformation) : TaskInformation {
+    accept(taskInformation)
+    return taskInformation
+  }
+}

--- a/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/support/AssignmentDetector.kt
+++ b/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/support/AssignmentDetector.kt
@@ -1,0 +1,17 @@
+package dev.bpmcrafters.processengineapi.task.support
+
+import dev.bpmcrafters.processengineapi.task.TaskInformation
+
+/**
+ * Detects assignment changes.
+ * @since 1.1
+ */
+interface AssignmentDetector {
+  /**
+   * Detects if assignment has changed from old to new task information.
+   * @param oldTaskInformation old task information and payload.
+   * @param newTaskInformation new task information and payload.
+   * @return true, if assignment change is detected. Defaults to `false`.
+   */
+  fun hasChangedAssignment(oldTaskInformation: Pair<TaskInformation, Map<String, Any>>, newTaskInformation: Pair<TaskInformation, Map<String, Any>>): Boolean = false
+}

--- a/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/support/CompositeTaskHandler.kt
+++ b/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/support/CompositeTaskHandler.kt
@@ -29,7 +29,7 @@ class CompositeTaskHandler(
   }
 
   override fun accept(taskInformation: TaskInformation, payload: Map<String, Any>) {
-    handlers.forEach { it.accept(taskInformation, payload) }
+    handlers.fold( Pair(taskInformation, payload)) { params, handler -> handler.process(params) }
   }
 
 }

--- a/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/support/CompositeTaskTerminationHandler.kt
+++ b/api/src/main/kotlin/dev/bpmcrafters/processengineapi/task/support/CompositeTaskTerminationHandler.kt
@@ -1,5 +1,6 @@
 package dev.bpmcrafters.processengineapi.task.support
 
+import dev.bpmcrafters.processengineapi.task.TaskInformation
 import dev.bpmcrafters.processengineapi.task.TaskTerminationHandler
 
 /**
@@ -28,7 +29,7 @@ class CompositeTaskTerminationHandler(
     this.handlers.add(handler)
   }
 
-  override fun accept(taskId: String) {
-    handlers.forEach { it.accept(taskId) }
+  override fun accept(taskInformation: TaskInformation) {
+    handlers.fold(taskInformation) { ti, handler -> handler.process(ti) }
   }
 }

--- a/api/src/test/kotlin/dev/bpmcrafters/processengineapi/task/support/UserTaskSupportTest.kt
+++ b/api/src/test/kotlin/dev/bpmcrafters/processengineapi/task/support/UserTaskSupportTest.kt
@@ -9,15 +9,19 @@ import java.util.*
 
 internal class UserTaskSupportTest {
 
-  private val support = UserTaskSupport()
+  private val support = UserTaskSupport(assignmentDetector = object: AssignmentDetector {
+    override fun hasChangedAssignment(oldTaskInformation: Pair<TaskInformation, Map<String, Any>>, newTaskInformation: Pair<TaskInformation, Map<String, Any>>): Boolean {
+      return oldTaskInformation.first.meta["custom-assignment-field"] != newTaskInformation.first.meta["custom-assignment-field"]
+    }
+  })
 
   @Test
   fun `acts as composite task handler`() {
-    var delivered: String? = null
-    var removed: String? = null
+    var delivered: TaskInformation? = null
+    var removed: TaskInformation? = null
 
-    support.addHandler { ti, _ -> delivered = ti.taskId }
-    support.addTerminationHandler { id -> removed = id }
+    support.addHandler { ti, _ -> delivered = ti }
+    support.addTerminationHandler { ti -> removed = ti }
 
     val taskId = UUID.randomUUID().toString()
     val task = TaskInformation(taskId, mapOf(CommonRestrictions.ACTIVITY_ID to "some"))
@@ -37,16 +41,81 @@ internal class UserTaskSupportTest {
     assertThat(support.exists(taskId, "some")).isTrue()
     assertThat(support.getAllTasks()).containsExactly(task)
     assertThat(support.getPayload(taskId)).containsAllEntriesOf(payload)
-    assertThat(delivered).isEqualTo(taskId)
+    assertThat(delivered).isEqualTo(task)
     assertThat(removed).isNull()
 
     // when
-    support.onTaskRemoval(taskId)
+    support.onTaskRemoval(task)
 
     // then
     assertThat(support.getAllTasks()).isEmpty()
     assertThat(support.exists(taskId)).isFalse()
-    assertThat(delivered).isEqualTo(taskId)
-    assertThat(removed).isEqualTo(taskId)
+    assertThat(delivered).isEqualTo(task)
+    assertThat(removed).isEqualTo(task)
   }
+
+  @Test
+  fun `handles reason propagation correctly`() {
+    var reason: String? = null
+    var terminationReason: String? = null
+    support.addHandler { ti, _ -> reason = ti.meta[TaskInformation.REASON] }
+    support.addTerminationHandler { ti -> terminationReason = ti.meta[TaskInformation.REASON] }
+
+    val taskId = UUID.randomUUID().toString()
+    val payload = mapOf("key" to "value")
+
+    // create
+    support.onTaskDelivery(
+      TaskInformation(taskId, mapOf(CommonRestrictions.ACTIVITY_ID to "some")).withReason(TaskInformation.CREATE),
+      payload
+    )
+    assertThat(reason).isEqualTo(TaskInformation.CREATE)
+    assertThat(terminationReason).isNull()
+    assertThat(support.exists(taskId)).isTrue()
+    assertThat(support.getTaskInformation(taskId).meta).doesNotContainKeys(TaskInformation.REASON)
+
+    // update
+    support.onTaskDelivery(
+      TaskInformation(taskId, mapOf(CommonRestrictions.ACTIVITY_ID to "some")).withReason(TaskInformation.UPDATE),
+      payload + ("other key" to "other value")
+    )
+    assertThat(reason).isEqualTo(TaskInformation.UPDATE)
+    assertThat(terminationReason).isNull()
+    assertThat(support.exists(taskId)).isTrue()
+    assertThat(support.getTaskInformation(taskId).meta).doesNotContainKeys(TaskInformation.REASON)
+
+    // assign
+    support.onTaskDelivery(
+      TaskInformation(taskId, mapOf(CommonRestrictions.ACTIVITY_ID to "some", "custom-assignment-field" to "kermit")).withReason(TaskInformation.UPDATE),
+      payload + ("other key" to "other value")
+    )
+    assertThat(reason).isEqualTo(TaskInformation.ASSIGN)
+    assertThat(terminationReason).isNull()
+    assertThat(support.exists(taskId)).isTrue()
+    assertThat(support.getTaskInformation(taskId).meta).doesNotContainKeys(TaskInformation.REASON)
+
+    // complete
+    reason = "foo"
+    support.onTaskRemoval(TaskInformation(taskId, mapOf(CommonRestrictions.ACTIVITY_ID to "some")).withReason(TaskInformation.COMPLETE))
+    assertThat(reason).isEqualTo("foo")
+    assertThat(terminationReason).isEqualTo(TaskInformation.COMPLETE)
+    assertThat(support.exists(taskId)).isFalse()
+
+    // create again
+    support.onTaskDelivery(
+      TaskInformation(taskId, mapOf(CommonRestrictions.ACTIVITY_ID to "some")).withReason(TaskInformation.CREATE),
+      payload
+    )
+    assertThat(support.exists(taskId)).isTrue()
+
+    // delete
+    reason = "bar"
+    support.onTaskRemoval(TaskInformation(taskId, mapOf(CommonRestrictions.ACTIVITY_ID to "some")).withReason(TaskInformation.DELETE))
+    assertThat(reason).isEqualTo("bar")
+    assertThat(terminationReason).isEqualTo(TaskInformation.DELETE)
+    assertThat(support.exists(taskId)).isFalse()
+
+  }
+
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,7 @@
         <groupId>org.jetbrains.kotlin</groupId>
         <configuration>
           <jvmTarget>17</jvmTarget>
+          <args>-Xjvm-default=all-compatibility</args>
           <compilerPlugins>
             <plugin>spring</plugin>
             <plugin>no-arg</plugin>


### PR DESCRIPTION
- Termination handlers now receive `TaskInformation` instead of String (task id only)
- `User Task Support` can detect (and propagate) `ASSIGN` reason in metadata to the handler
- Creation of commands from values instead of suppliers is now supported
- fix #224
- fix #226 
- fix #223 