### PR TITLE
feat: add StartProcessByMessageAtElementCmd to process API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ build/
 ### DEV
 _tmp/
 .repository/
+.claude/logs/

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ If you want to try the API, please refer to one of the adapter implementations m
 | Start Process by definition    | ✅           | ✅         | ✅    | ✅  |
 | Start Process by definition at | ✅           | ✅         | ✅    | ✅  |
 | Start Process by message       | ✅           | ✅         | ✅    | ✅  |
+| Start Process by message at    | 🚧           | 🚧         | 🚧    | ❌  |
 | Correlate message              | ✅           | ✅         | ✅    | ✅  |
 | Send signal                    | ✅           | ✅         | ✅    | ✅  |
 | Subscribe to task              | ✅           | ✅         | ✅    | ✅  |
@@ -61,6 +62,8 @@ If you want to try the API, please refer to one of the adapter implementations m
 | Complete service task          | ✅           | ✅         | ✅    | ✅  |
 | Complete service task by error | ✅           | ✅         | ✅    | ✅  |
 | Fail service task              | ✅           | ✅         | ✅    | ✅  |
+
+*✅ supported · 🚧 in development · ❌ not supported*
 
 ## Process Engine Worker
 

--- a/api/src/main/kotlin/dev/bpmcrafters/processengineapi/process/StartProcessByMessageAtElementCmd.kt
+++ b/api/src/main/kotlin/dev/bpmcrafters/processengineapi/process/StartProcessByMessageAtElementCmd.kt
@@ -1,0 +1,65 @@
+package dev.bpmcrafters.processengineapi.process
+
+import dev.bpmcrafters.processengineapi.PayloadSupplier
+
+/**
+ * Command to start a new process instance by message at a specific element.
+ * Useful for processes that have no plain (none) start event and are entered
+ * only via one or multiple message start events.
+ * @since 1.7
+ */
+data class StartProcessByMessageAtElementCmd(
+  /**
+   * Name of the message.
+   */
+  val messageName: String,
+  /**
+   * ID of the element to start the process at.
+   */
+  val elementId: String,
+  /**
+   * Payload supplier to pass to the new process instance.
+   */
+  val payloadSupplier: PayloadSupplier,
+  /**
+   * Restrictions applied for this start command.
+   */
+  val restrictions: Map<String, String> = emptyMap()
+) : StartProcessCommand, PayloadSupplier by payloadSupplier {
+  /**
+   * Constructs a start command with a message name, element ID, payload, and restrictions.
+   * @param messageName message name.
+   * @param elementId element ID to start the process at.
+   * @param payload payload to use.
+   * @param restrictions restrictions for the start command.
+   */
+  constructor(messageName: String, elementId: String, payload: Map<String, Any?>, restrictions: Map<String, String>) : this(
+    messageName = messageName,
+    elementId = elementId,
+    payloadSupplier = PayloadSupplier { payload },
+    restrictions = restrictions
+  )
+  /**
+   * Constructs a start command with a message name, element ID, and payload.
+   * @param messageName message name.
+   * @param elementId element ID to start the process at.
+   * @param payload payload to use.
+   */
+  constructor(messageName: String, elementId: String, payload: Map<String, Any?>) : this(
+    messageName = messageName,
+    elementId = elementId,
+    payloadSupplier = PayloadSupplier { payload } ,
+    restrictions = mapOf()
+  )
+
+  /**
+   * Constructs a start command with message name, element ID, and no payload.
+   * @param messageName message name.
+   * @param elementId element ID to start the process at.
+   */
+  constructor(messageName: String, elementId: String) : this(
+    messageName = messageName,
+    elementId = elementId,
+    payload = mapOf(),
+  )
+}

--- a/api/src/test/kotlin/dev/bpmcrafters/processengineapi/process/StartProcessByMessageAtElementCmdTest.kt
+++ b/api/src/test/kotlin/dev/bpmcrafters/processengineapi/process/StartProcessByMessageAtElementCmdTest.kt
@@ -1,0 +1,59 @@
+package dev.bpmcrafters.processengineapi.process
+
+import dev.bpmcrafters.processengineapi.CommonRestrictions
+import dev.bpmcrafters.processengineapi.PayloadSupplier
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class StartProcessByMessageAtElementCmdTest {
+
+  @Test
+  fun `should create command with payload supplier and restrictions`() {
+    val payload = mapOf<String, Any?>("order" to "4711")
+    val restrictions = mapOf(CommonRestrictions.TENANT_ID to "myTenant")
+    val cmd = StartProcessByMessageAtElementCmd(
+      messageName = "Msg_OrderReceived",
+      elementId = "Activity_ProcessOrder",
+      payloadSupplier = PayloadSupplier { payload },
+      restrictions = restrictions
+    )
+
+    assertThat(cmd.messageName).isEqualTo("Msg_OrderReceived")
+    assertThat(cmd.elementId).isEqualTo("Activity_ProcessOrder")
+    assertThat(cmd.get()).isEqualTo(payload)
+    assertThat(cmd.restrictions).isEqualTo(restrictions)
+  }
+
+  @Test
+  fun `should create command from payload and restrictions`() {
+    val payload = mapOf<String, Any?>("order" to "4711")
+    val restrictions = mapOf(CommonRestrictions.TENANT_ID to "myTenant")
+    val cmd = StartProcessByMessageAtElementCmd("Msg_OrderReceived", "Activity_ProcessOrder", payload, restrictions)
+
+    assertThat(cmd.messageName).isEqualTo("Msg_OrderReceived")
+    assertThat(cmd.elementId).isEqualTo("Activity_ProcessOrder")
+    assertThat(cmd.get()).isEqualTo(payload)
+    assertThat(cmd.restrictions).isEqualTo(restrictions)
+  }
+
+  @Test
+  fun `should create command from payload with empty restrictions`() {
+    val payload = mapOf<String, Any?>("order" to "4711")
+    val cmd = StartProcessByMessageAtElementCmd("Msg_OrderReceived", "Activity_ProcessOrder", payload)
+
+    assertThat(cmd.messageName).isEqualTo("Msg_OrderReceived")
+    assertThat(cmd.elementId).isEqualTo("Activity_ProcessOrder")
+    assertThat(cmd.get()).isEqualTo(payload)
+    assertThat(cmd.restrictions).isEmpty()
+  }
+
+  @Test
+  fun `should create command without payload and restrictions`() {
+    val cmd = StartProcessByMessageAtElementCmd("Msg_OrderReceived", "Activity_ProcessOrder")
+
+    assertThat(cmd.messageName).isEqualTo("Msg_OrderReceived")
+    assertThat(cmd.elementId).isEqualTo("Activity_ProcessOrder")
+    assertThat(cmd.get()).isEmpty()
+    assertThat(cmd.restrictions).isEmpty()
+  }
+}

--- a/docs/process-api.md
+++ b/docs/process-api.md
@@ -7,10 +7,11 @@ It allows to start new process instances.
 It is intended to be used in outbound adapters of the port/adapter architecture 
 to control the process engine from your application.
 
-There are three ways to start processes:
+There are four ways to start processes:
 * by providing a process definition key
 * by providing a start message
 * by providing a process definition key and a specific activity to start at
+* by providing a start message and a specific activity to start at
 
 In all cases, you might provide a process payload passed to the started process instance. 
 
@@ -50,6 +51,18 @@ public class ProcessStarter {
     startProcessApi.startProcess(
       new StartProcessByDefinitionAtElementCmd(
         "MyExampleProcessKey",
+        "Activity_ProcessOrder",
+        () -> Map.of("order", order),
+        Map.of()
+      )
+    ).get();
+  }
+
+  @SneakyThrows
+  public void startByMessageAtActivity(Order order) {
+    startProcessApi.startProcess(
+      new StartProcessByMessageAtElementCmd(
+        "Msg_OrderReceived",
         "Activity_ProcessOrder",
         () -> Map.of("order", order),
         Map.of()


### PR DESCRIPTION
## What

Adds `StartProcessByMessageAtElementCmd` to the Process API — analogous to the existing `StartProcessByDefinitionAtElementCmd`, but it starts a process at a specific element via a **message name** instead of a definition key.

This enables starting at a given element for processes that have **no plain (none) start event** and are entered only through one or multiple **message start events** — the use case described in #292.

## Changes

- **New command** `api/.../process/StartProcessByMessageAtElementCmd.kt` (`messageName`, `elementId`, payload, restrictions), with the same Java-friendly constructor overloads as its definition-based sibling. Tagged `@since 1.7`. No dispatch changes needed — `StartProcessApi.startProcess(...)` accepts it polymorphically.
- **Docs** `docs/process-api.md`: intro now lists four start variants and includes a `startByMessageAtActivity(...)` example.
- **README** feature matrix: new `Start Process by message at` row + an icon legend.

## Adapter support

The matrix marks the new feature 🚧 (in development) for C7 embedded, C7 remote and CIB7, and ❌ for C8.

C8/Zeebe is not technically supportable: `CreateProcessInstance` with `startInstructions` starts by process definition id (not message), and `PublishMessage` has no `startInstructions` — the two cannot be combined, and there is no API to resolve a message name to its owning definition.

Adapter implementations are tracked in separate tickets and are **out of scope** for this PR:
- CIB Seven — bpm-crafters/process-engine-adapters-cib-seven#73
- Camunda 7 — bpm-crafters/process-engine-adapters-camunda-7#199
- Camunda 8 — bpm-crafters/process-engine-adapters-camunda-8#233

## Docs delivery

The published docs site (`process-engine-api-docs`) imports `docs/**/*.md` from this repo's `develop` branch at build time via the mkdocs-multirepo plugin, so no separate docs-repo PR is needed. The site rebuilds on its own push/tag (left to the release).

Refs #292