### PR TITLE
chore(ci): pin github actions to exact version tags

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -34,14 +34,14 @@ jobs:
     steps:
       # Checkout the code
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
 
       - name: Expose branch name
         run: echo ${{ github.ref }}
 
       # Setup JDK and Maven
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.3.0
         with:
           java-version-file: .java-version
           distribution: 'zulu'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,11 +14,11 @@ jobs:
     name: Build and run tests
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
 
       # Setup JDK and .m2/settings.xml
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.3.0
         with:
           java-version-file: .java-version
           distribution: 'zulu'

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@master
+      uses: actions/checkout@v7.0.0
     - name: Create Release Notes Markdown
       uses: docker://ghcr.io/rohwerj/release-notes-generator-action:v1.0.0
       env:
@@ -27,7 +27,7 @@ jobs:
         echo "VERSION=$VERSION" >> $GITHUB_ENV
     - name: Create a Draft Release Notes on GitHub
       id: create_release
-      uses: actions/create-release@v1
+      uses: actions/create-release@v1.1.4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:


### PR DESCRIPTION
## What

Pin all external GitHub Actions to exact, full-semver version tags (`@vX.Y.Z`) instead of moving references (major-only `@vX` or branch refs like `@master`).

## Why

Moving refs silently absorb new releases within a major version (and, for branch refs, *any* push). That makes CI runs non-reproducible and exposes the pipeline to unreviewed upstream changes. Pinning to an exact tag protects against major/minor drift.

## Mapping

| Action | Before | After |
|---|---|---|
| `actions/checkout` (development.yml, master.yml) | `@v7` | `@v7.0.0` |
| `actions/setup-java` (development.yml, master.yml) | `@v5` | `@v5.3.0` |
| `actions/checkout` (release-notes.yml) | `@master` ⚠️ | `@v7.0.0` |
| `actions/create-release` (release-notes.yml) | `@v1` | `@v1.1.4` |

⚠️ **Branch ref**: `release-notes.yml` was checking out `actions/checkout@master`, i.e. tracking the action's development branch — now pinned to the latest stable release `v7.0.0`.

Left untouched (already exact): `codecov/codecov-action@v7.0.0` and the docker image `docker://ghcr.io/rohwerj/release-notes-generator-action:v1.0.0`. Local reusable workflows (`./...`) are not affected.

All updates stay within the same major version, so no breaking changes are expected.

## Note

Tag-pinning protects against major/minor drift. The next hardening step would be **full-SHA pinning** (`@<40-char-sha>`), which also defends against tag re-pointing — out of scope for this PR.