### PR TITLE
docs: document Operaton adapter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Purpose of the library
 
 This library provides a modern engine-agnostic API which can be used to implement process applications. By providing a set
-of adapters to relevant process engines (Camunda Platform 7, Camunda Platform 8, etc...) the library enforces separation of
+of adapters to relevant process engines (Camunda Platform 7, Camunda Platform 8, Operaton, etc...) the library enforces separation of
 the integration of process engine from the selection of the used engine. This approach fosters an easy migration between engines
 and tries to achieve to support migrations with minimal (or even no) code modifications.
 
@@ -42,26 +42,28 @@ If you want to try the API, please refer to one of the adapter implementations m
 
 - [CIB-Seven Adapter](https://github.com/bpm-crafters/process-engine-adapters-cib-seven) [![Maven Central Version](https://img.shields.io/maven-central/v/dev.bpm-crafters.process-engine-adapters/process-engine-adapter-cib-seven-root)](https://central.sonatype.org/artifact/dev.bpm-crafters.process-engine-adapters/process-engine-adapter-cib-seven-root)
 
+- [Operaton Adapter](https://github.com/bpm-crafters/process-engine-adapters-operaton) [![Maven Central Version](https://img.shields.io/maven-central/v/dev.bpm-crafters.process-engine-adapters/process-engine-adapter-operaton-root)](https://central.sonatype.com/artifact/dev.bpm-crafters.process-engine-adapters/process-engine-adapter-operaton-root)
+
 ## Feature supported by adapters
 
 
-|                                | C7 embedded | C7 remote | CIB7 | C8 |
-|--------------------------------|-------------|-----------|------|----|
-| Deployment                     | ✅           | ✅         | ✅    | ✅  |
-| Decision Evaluation            | ✅           | ✅         | ❌    | ✅  |
-| Start Process by definition    | ✅           | ✅         | ✅    | ✅  |
-| Start Process by definition at | ✅           | ✅         | ✅    | ✅  |
-| Start Process by message       | ✅           | ✅         | ✅    | ✅  |
-| Start Process by message at    | ✅           | ✅         | ✅    | ❌  |
-| Correlate message              | ✅           | ✅         | ✅    | ✅  |
-| Send signal                    | ✅           | ✅         | ✅    | ✅  |
-| Subscribe to task              | ✅           | ✅         | ✅    | ✅  |
-| Complete user task             | ✅           | ✅         | ✅    | ✅  |
-| Complete user task by error    | ✅           | ✅         | ✅    | ✅  |
-| Modify user task               | ✅           | ✅         | ✅    | ❌  |
-| Complete service task          | ✅           | ✅         | ✅    | ✅  |
-| Complete service task by error | ✅           | ✅         | ✅    | ✅  |
-| Fail service task              | ✅           | ✅         | ✅    | ✅  |
+|                                | C7 embedded | C7 remote | CIB7 | C8 | Operaton embedded | Operaton remote |
+|--------------------------------|-------------|-----------|------|----|-------------------|-----------------|
+| Deployment                     | ✅           | ✅         | ✅    | ✅  | ✅                 | ✅               |
+| Decision Evaluation            | ✅           | ✅         | ❌    | ✅  | ✅                 | ✅               |
+| Start Process by definition    | ✅           | ✅         | ✅    | ✅  | ✅                 | ✅               |
+| Start Process by definition at | ✅           | ✅         | ✅    | ✅  | ✅                 | ✅               |
+| Start Process by message       | ✅           | ✅         | ✅    | ✅  | ✅                 | ✅               |
+| Start Process by message at    | ✅           | ✅         | ✅    | ❌  | ✅                 | ✅               |
+| Correlate message              | ✅           | ✅         | ✅    | ✅  | ✅                 | ✅               |
+| Send signal                    | ✅           | ✅         | ✅    | ✅  | ✅                 | ✅               |
+| Subscribe to task              | ✅           | ✅         | ✅    | ✅  | ✅                 | ✅               |
+| Complete user task             | ✅           | ✅         | ✅    | ✅  | ✅                 | ✅               |
+| Complete user task by error    | ✅           | ✅         | ✅    | ✅  | ✅                 | ✅               |
+| Modify user task               | ✅           | ✅         | ✅    | ❌  | ✅                 | ✅               |
+| Complete service task          | ✅           | ✅         | ✅    | ✅  | ✅                 | ✅               |
+| Complete service task by error | ✅           | ✅         | ✅    | ✅  | ✅                 | ✅               |
+| Fail service task              | ✅           | ✅         | ✅    | ✅  | ✅                 | ✅               |
 
 *✅ supported · 🚧 in development · ❌ not supported*
 

--- a/docs/process-api.md
+++ b/docs/process-api.md
@@ -73,7 +73,7 @@ public class ProcessStarter {
 }
 ```
 
-For supported engines (currently only C7 Embedded and C7 Remote) it is possible to set a business key by providing it 
+For supported engines (currently C7 Embedded, C7 Remote, Operaton Embedded and Operaton Remote) it is possible to set a business key by providing it 
 in the payload supplier, for example:
 ```java
 @SneakyThrows


### PR DESCRIPTION
Documents the newly added [Operaton adapter](https://github.com/bpm-crafters/process-engine-adapters-operaton) in the project docs. In the README, Operaton is added to the purpose section and listed under **Available Engine Adapters** with its Maven Central badge (`process-engine-adapter-operaton-root`), and the feature-support matrix gains **Operaton embedded** and **Operaton remote** columns mirroring C7, from which the adapter is derived as an API-compatible fork. `docs/process-api.md` is updated to note that the business-key feature is now also supported by Operaton Embedded and Operaton Remote. All claims were verified against the upstream adapter repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)